### PR TITLE
feat!: remove Promise support from tryOr and tryOrElse

### DIFF
--- a/try_or.ts
+++ b/try_or.ts
@@ -1,28 +1,17 @@
-import { tryOrElse } from "./try_or_else.ts";
 /**
- * Try to execute a function and return the result or a default value.
+ * Try to execute a function and return the result or a default value if an error occurs.
  *
  * ```ts
  * import { tryOr } from "@core/errorutil/try-or";
- * import { raise } from "@core/errorutil/raise";
  *
- * // Sync
  * console.log(tryOr(() => 1, 2)); // 1
- * console.log(tryOr(() => raise("err"), 2)); // 2
- *
- * // Async
- * console.log(await tryOr(() => Promise.resolve(1), 2)); // 1
- * console.log(await tryOr(() => Promise.reject("err"), 2)); // 2
+ * console.log(tryOr(() => { throw "err"; }, 2)); // 2
  * ```
  */
-export function tryOr<T>(fn: () => T, orValue: T): T;
-export function tryOr<T>(
-  fn: () => Promise<T>,
-  orValue: T | Promise<T>,
-): Promise<T>;
-export function tryOr<T>(
-  fn: () => T | Promise<T>,
-  orValue: T,
-): T | Promise<T> {
-  return tryOrElse(fn, () => orValue);
+export function tryOr<T>(fn: () => T, orValue: T): T {
+  try {
+    return fn();
+  } catch {
+    return orValue;
+  }
 }

--- a/try_or_else.ts
+++ b/try_or_else.ts
@@ -1,34 +1,16 @@
 /**
- * Try to execute a function and return the result or execute another function.
+ * Try to execute a function and return the result or execute another function and return its result if an error occurs.
  *
  * ```ts
  * import { tryOrElse } from "@core/errorutil/try-or-else";
- * import { raise } from "@core/errorutil/raise";
  *
- * // Sync
  * console.log(tryOrElse(() => 1, () => 2)); // 1
- * console.log(tryOrElse(() => raise("err"), () => 2)); // 2
- *
- * // Async
- * console.log(await tryOrElse(() => Promise.resolve(1), () => 2)); // 1
- * console.log(await tryOrElse(() => Promise.reject("err"), () => 2)); // 2
+ * console.log(tryOrElse(() => { throw "err" }, () => 2)); // 2
  * ```
  */
-export function tryOrElse<T>(fn: () => T, elseFn: (err: unknown) => T): T;
-export function tryOrElse<T>(
-  fn: () => Promise<T>,
-  elseFn: (err: unknown) => T | Promise<T>,
-): Promise<T>;
-export function tryOrElse<T>(
-  fn: () => T | Promise<T>,
-  elseFn: (err: unknown) => T | Promise<T>,
-): T | Promise<T> {
+export function tryOrElse<T>(fn: () => T, elseFn: (err: unknown) => T): T {
   try {
-    const ret = fn();
-    if (ret instanceof Promise) {
-      return ret.catch((err) => elseFn(err));
-    }
-    return ret;
+    return fn();
   } catch (err) {
     return elseFn(err);
   }

--- a/try_or_else_test.ts
+++ b/try_or_else_test.ts
@@ -1,57 +1,20 @@
 import { test } from "@cross/test";
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { raise } from "./raise.ts";
 import { tryOrElse } from "./try_or_else.ts";
 
-const err = new Error("error");
-const resolve = Promise.resolve.bind(Promise);
-const reject = Promise.reject.bind(Promise);
-
-await test("tryOrElse (sync)", () => {
-  type T = number;
-  assertEquals(tryOrElse((): T => 1, () => 2), 1);
-  assertEquals(tryOrElse((): T => raise(err), () => 2), 2);
+await test("tryOrElse executes the first function and return the result", () => {
+  assertEquals(tryOrElse(() => 1, () => 2), 1);
 });
 
-await test("tryOrElse with Error (sync)", () => {
-  type T = number;
+await test("tryOrElse executes the second function and return the result if the first function throws error", () => {
+  assertEquals(tryOrElse(() => raise("err"), () => 2), 2);
+});
+
+await test("tryOrElse throws error if the second function throws error", () => {
   assertThrows(
-    () => tryOrElse((): T => raise(err), () => raise(err)),
+    () => tryOrElse(() => raise("err1"), () => raise(new Error("err2"))),
     Error,
-    "error",
-  );
-});
-
-await test("tryOrElse (async)", async () => {
-  type T = Promise<number>;
-  assertEquals(await tryOrElse((): T => resolve(1), () => 2), 1);
-  assertEquals(await tryOrElse((): T => resolve(1), () => resolve(2)), 1);
-  assertEquals(await tryOrElse((): T => reject(err), () => 2), 2);
-  assertEquals(await tryOrElse((): T => reject(err), () => resolve(2)), 2);
-  assertEquals(await tryOrElse((): T => raise(err), () => 2), 2);
-  assertEquals(await tryOrElse((): T => raise(err), () => resolve(2)), 2);
-});
-
-await test("tryOrElse with Error (async)", async () => {
-  type T = Promise<number>;
-  await assertRejects(
-    () => tryOrElse((): T => reject(err), () => reject(err)),
-    Error,
-    "error",
-  );
-  await assertRejects(
-    () => tryOrElse((): T => reject(err), () => raise(err)),
-    Error,
-    "error",
-  );
-  await assertRejects(
-    () => tryOrElse((): T => raise(err), () => reject(err)),
-    Error,
-    "error",
-  );
-  assertThrows(
-    () => tryOrElse((): T => raise(err), () => raise(err)),
-    Error,
-    "error",
+    "err2",
   );
 });

--- a/try_or_test.ts
+++ b/try_or_test.ts
@@ -3,22 +3,10 @@ import { assertEquals } from "@std/assert";
 import { raise } from "./raise.ts";
 import { tryOr } from "./try_or.ts";
 
-const err = new Error("error");
-const resolve = Promise.resolve.bind(Promise);
-const reject = Promise.reject.bind(Promise);
-
-await test("tryOr (sync)", () => {
-  type T = number;
-  assertEquals(tryOr((): T => 1, 2), 1);
-  assertEquals(tryOr((): T => raise(err), 2), 2);
+await test("tryOr executes the function and return the result", () => {
+  assertEquals(tryOr(() => 1, 2), 1);
 });
 
-await test("tryOr (async)", async () => {
-  type T = Promise<number>;
-  assertEquals(await tryOr((): T => resolve(1), 2), 1);
-  assertEquals(await tryOr((): T => resolve(1), resolve(2)), 1);
-  assertEquals(await tryOr((): T => reject(err), 2), 2);
-  assertEquals(await tryOr((): T => reject(err), resolve(2)), 2);
-  assertEquals(await tryOr((): T => raise(err), 2), 2);
-  assertEquals(await tryOr((): T => raise(err), resolve(2)), 2);
+await test("tryOr returns the orValue if the function throws error", () => {
+  assertEquals(tryOr(() => raise("err"), 2), 2);
 });


### PR DESCRIPTION
Use `.catch()` instead

```ts
await Promise.reject(1).catch(() => 2);
```