### PR TITLE
feat: add `alter` and `alterElse` to alter thrown error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@
 
 A utility pack for handling error.
 
+## alter / alterElse
+
+`alter` and `alterElse` are functions that execute a function and return the
+result. If the function throws an error, `alter` throws the given error, and
+`alterElse` throws the result of the second function.
+
+```ts
+import { assertThrows } from "@std/assert";
+import { alter } from "@core/errorutil/alter";
+import { alterElse } from "@core/errorutil/alter-else";
+
+const fn = () => {
+  throw new Error("This is an error message");
+};
+
+assertThrows(() => alter(fn, new Error("custom error")), Error, "custom error");
+
+assertThrows(
+  () => alterElse(fn, () => new Error("custom error")),
+  Error,
+  "custom error",
+);
+```
+
 ## attempt
 
 `attempt` is a function that executes a function and returns the result

--- a/alter.ts
+++ b/alter.ts
@@ -1,0 +1,23 @@
+/**
+ * Alter the error of a function if an error is thrown.
+ *
+ * @param fn - The function to execute.
+ * @param alt - The value to throw if an error is thrown.
+ * @returns The result of the function.
+ * @throws The value of alt.
+ * @example
+ *
+ * ```ts
+ * import { alter } from "@core/errorutil/alter";
+ *
+ * console.log(alter(() => 1, "err2")); // 1
+ * console.log(alter(() => { throw "err1" }, "err2")); // "err2" is thrown
+ * ```
+ */
+export function alter<T, E>(fn: () => T, alt: E): T {
+  try {
+    return fn();
+  } catch {
+    throw alt;
+  }
+}

--- a/alter_else.ts
+++ b/alter_else.ts
@@ -1,0 +1,23 @@
+/**
+ * Alter the error of a function if an error is thrown.
+ *
+ * @param fn - The function to execute.
+ * @param modifier - The function to execute if an error is thrown.
+ * @returns The result of the function.
+ * @throws The result of the modifier function.
+ * @example
+ *
+ * ```ts
+ * import { alterElse } from "@core/errorutil/alter-else";
+ *
+ * console.log(alterElse(() => 1, () => "err")); // 1
+ * console.log(alterElse(() => { throw "err" }, (err) => "new " + err)); // "new err" is thrown
+ * ```
+ */
+export function alterElse<T, E>(fn: () => T, elseFn: (err: unknown) => E): T {
+  try {
+    return fn();
+  } catch (err) {
+    throw elseFn(err);
+  }
+}

--- a/alter_else_test.ts
+++ b/alter_else_test.ts
@@ -1,0 +1,16 @@
+import { test } from "@cross/test";
+import { assertEquals, assertThrows } from "@std/assert";
+import { raise } from "./raise.ts";
+import { alterElse } from "./alter_else.ts";
+
+test("alterElse should return a function result", () => {
+  assertEquals(alterElse(() => 1, () => "err2"), 1);
+});
+
+test("alterElse should throws an alt when the function throws error", () => {
+  assertThrows(
+    () => alterElse(() => raise("err"), (err) => new Error(`new ${err}`)),
+    Error,
+    "new err",
+  );
+});

--- a/alter_test.ts
+++ b/alter_test.ts
@@ -1,0 +1,16 @@
+import { test } from "@cross/test";
+import { assertEquals, assertThrows } from "@std/assert";
+import { raise } from "./raise.ts";
+import { alter } from "./alter.ts";
+
+test("alter should return a function result", () => {
+  assertEquals(alter(() => 1, "err2"), 1);
+});
+
+test("alter should throws an alt when the function throws error", () => {
+  assertThrows(
+    () => alter(() => raise("err1"), new Error("err2")),
+    Error,
+    "err2",
+  );
+});

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,6 +3,8 @@
   "version": "0.0.0",
   "exports": {
     ".": "./mod.ts",
+    "./alter": "./alter.ts",
+    "./alter-else": "./alter_else.ts",
     "./attempt": "./attempt.ts",
     "./error-object": "./error_object.ts",
     "./raise": "./raise.ts",
@@ -28,6 +30,8 @@
   },
   "imports": {
     "@core/errorutil": "./mod.ts",
+    "@core/errorutil/alter": "./alter.ts",
+    "@core/errorutil/alter-else": "./alter_else.ts",
     "@core/errorutil/attempt": "./attempt.ts",
     "@core/errorutil/error-object": "./error_object.ts",
     "@core/errorutil/raise": "./raise.ts",


### PR DESCRIPTION
Like

```ts
import { assert, is } from "@core/unknownutil";
import { alter } from "@core/errorutil";

const v: unknown = "";
alter(() => assert(v, is.Number), new Error("v must be number"));
```