### PR TITLE
feat: add asyncAttempt function

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,8 @@
 # These are supported funding model platforms
 
-github: [lambdalisue] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [
+  lambdalisue,
+] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ assertEquals(
 
 ## asyncAttempt
 
-`asyncAttempt` is a function that executes a async function and returns the result
-(`Promise<[error: unknown, value: T]>`). If the function is successful, it returns
-`Promise.resolve([undefined, value])`. If the function throws an error, it returns
-`Promise.resolve([error, undefined])`.
+`asyncAttempt` is a function that executes a async function and returns the
+result (`Promise<[error: unknown, value: T]>`). If the function is successful,
+it returns `Promise.resolve([undefined, value])`. If the function throws an
+error, it returns `Promise.resolve([error, undefined])`.
 
 ```ts
 import { assertEquals } from "@std/assert";

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ error, it returns `Promise.resolve([error, undefined])`.
 
 ```ts
 import { assertEquals } from "@std/assert";
-import { attempt } from "@core/errorutil/attempt";
+import { asyncAttempt } from "@core/errorutil/async-attempt";
 
 assertEquals(await asyncAttempt(async () => 42), [undefined, 42]);
 assertEquals(

--- a/README.md
+++ b/README.md
@@ -41,9 +41,32 @@ assertThrows(
 import { assertEquals } from "@std/assert";
 import { attempt } from "@core/errorutil/attempt";
 
-assertEquals(attempt(() => 42), [undefined, 42]);
+assertEquals(
+  attempt(() => 42),
+  [undefined, 42],
+);
 assertEquals(
   attempt(() => {
+    throw "err";
+  }),
+  ["err", undefined],
+);
+```
+
+## asyncAttempt
+
+`asyncAttempt` is a function that executes a async function and returns the result
+(`Promise<[error: unknown, value: T]>`). If the function is successful, it returns
+`Promise.resolve([undefined, value])`. If the function throws an error, it returns
+`Promise.resolve([error, undefined])`.
+
+```ts
+import { assertEquals } from "@std/assert";
+import { attempt } from "@core/errorutil/attempt";
+
+assertEquals(await asyncAttempt(async () => 42), [undefined, 42]);
+assertEquals(
+  await asyncAttempt(async () => {
     throw "err";
   }),
   ["err", undefined],

--- a/async_attempt.ts
+++ b/async_attempt.ts
@@ -10,7 +10,7 @@ export type AsyncResult<T, E> = Promise<Result<T, E>>;
  *
  * @example
  * ```ts
- * import { asyncAttempt } from "@core/errorutil/async_attempt";
+ * import { asyncAttempt } from "@core/errorutil/async-attempt";
  *
  * console.log(await asyncAttempt(async () => 1)); // [undefined, 1]
  * console.log(await asyncAttempt(async () => { throw "err" })); // ["err", undefined]

--- a/async_attempt.ts
+++ b/async_attempt.ts
@@ -1,0 +1,27 @@
+import { Result } from "./attempt.ts";
+
+export type AsyncResult<T, E> = Promise<Result<T, E>>;
+
+/**
+ * Attempt to execute a async function and return a AsyncResult<T, E>.
+ *
+ * @param fn - The function to execute.
+ * @returns A AsyncResult<T, E> where T is the return type of the async function and E is the error type.
+ *
+ * @example
+ * ```ts
+ * import { asyncAttempt } from "@core/errorutil/async_attempt";
+ *
+ * console.log(await asyncAttempt(async () => 1)); // [undefined, 1]
+ * console.log(await asyncAttempt(async () => { throw "err" })); // ["err", undefined]
+ * ```
+ */
+export async function asyncAttempt<T, E = unknown>(
+  fn: () => Promise<T>,
+): Promise<Result<T, E>> {
+  try {
+    return [undefined, await fn()];
+  } catch (e) {
+    return [e as E, undefined];
+  }
+}

--- a/async_attempt.ts
+++ b/async_attempt.ts
@@ -1,4 +1,4 @@
-import { Result } from "./attempt.ts";
+import type { Result } from "./attempt.ts";
 
 export type AsyncResult<T, E> = Promise<Result<T, E>>;
 

--- a/async_attempt_test.ts
+++ b/async_attempt_test.ts
@@ -1,0 +1,15 @@
+import { test } from "@cross/test";
+import { assertEquals } from "@std/assert";
+import { asyncAttempt } from "./async_attempt.ts";
+
+test("asyncAttempt should return a Success<T> when the async function is successful", async () => {
+  const result = await asyncAttempt(async () => 1);
+  assertEquals(result, [undefined, 1]);
+});
+
+test("asyncAttempt should return a Failure<E> when the async function is failed", async () => {
+  const result = await asyncAttempt(async () => {
+    throw "err";
+  });
+  assertEquals(result, ["err", undefined]);
+});

--- a/async_attempt_test.ts
+++ b/async_attempt_test.ts
@@ -3,13 +3,11 @@ import { assertEquals } from "@std/assert";
 import { asyncAttempt } from "./async_attempt.ts";
 
 test("asyncAttempt should return a Success<T> when the async function is successful", async () => {
-  const result = await asyncAttempt(async () => 1);
+  const result = await asyncAttempt(() => Promise.resolve(1));
   assertEquals(result, [undefined, 1]);
 });
 
 test("asyncAttempt should return a Failure<E> when the async function is failed", async () => {
-  const result = await asyncAttempt(async () => {
-    throw "err";
-  });
+  const result = await asyncAttempt(() => Promise.reject("err"));
   assertEquals(result, ["err", undefined]);
 });

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,6 +5,7 @@
     ".": "./mod.ts",
     "./alter": "./alter.ts",
     "./alter-else": "./alter_else.ts",
+    "./async-attempt": "./async_attempt.ts",
     "./attempt": "./attempt.ts",
     "./error-object": "./error_object.ts",
     "./raise": "./raise.ts",
@@ -13,25 +14,16 @@
     "./unimplemented": "./unimplemented.ts",
     "./unreachable": "./unreachable.ts"
   },
-  "exclude": [
-    ".coverage/**"
-  ],
+  "exclude": [".coverage/**"],
   "publish": {
-    "include": [
-      "**/*.ts",
-      "README.md",
-      "LICENSE"
-    ],
-    "exclude": [
-      "**/*_bench.ts",
-      "**/*_test.ts",
-      ".*"
-    ]
+    "include": ["**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["**/*_bench.ts", "**/*_test.ts", ".*"]
   },
   "imports": {
     "@core/errorutil": "./mod.ts",
     "@core/errorutil/alter": "./alter.ts",
     "@core/errorutil/alter-else": "./alter_else.ts",
+    "@core/errorutil/async-attempt": "./async_attempt.ts",
     "@core/errorutil/attempt": "./attempt.ts",
     "@core/errorutil/error-object": "./error_object.ts",
     "@core/errorutil/raise": "./raise.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 export * from "./alter.ts";
 export * from "./alter_else.ts";
+export * from "./async_attempt.ts";
 export * from "./attempt.ts";
 export * from "./error_object.ts";
 export * from "./raise.ts";


### PR DESCRIPTION
Implement and add `AsyncAttempt` function. This function is based on the existing `attempt` implementation and returns the asynchronous function as a `Promise<Result<T, E>>`.
